### PR TITLE
Add svg_css-transform_preserve-3d crawler recipe

### DIFF
--- a/Recipe.min.js
+++ b/Recipe.min.js
@@ -1650,6 +1650,75 @@ void function() {
 }();
 
 /* 
+    RECIPE: svg_css-transform_preserve-3d
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of svg elements on page along with how many contain the transform CSS property and the transform-style CSS property with value preserve-3d in their namespace.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function svg_css_transform_preserve_3d(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "svg")
+            {
+                var elementsToCheck = [element];
+                var elementHasTranform = false;
+                var elementHas3DStyle = false;
+
+                while (elementsToCheck.length > 0 && (!elementHas3DStyle || !elementHasTranform))
+                {
+                    var children = [];
+
+                    for (var i = 0; i < elementsToCheck.length; ++i)
+                    {
+                        var e = elementsToCheck[i];
+
+                        // If no CSS on element, then don't do what is inside if statement, otherwise it will hit error.
+                        if (e.CSSUsage)
+                        {
+                            if (e.CSSUsage["transform"]) {
+                                elementHasTranform = true;
+                            }
+
+                            // We have to check for the transform-style property first before checking its values, otherwise it will hit error.
+                            var transformStyle = e.CSSUsage["transform-style"];
+                            if (transformStyle)
+                            {
+                                if (transformStyle.valuesArray.includes("preserve-3d")) {
+                                    elementHas3DStyle = true;
+                                }
+                            }
+                        }
+
+                        // Need to convert children HTML collection to array to combine with other children found.
+                        children = children.concat(Array.from(e.children));
+                    }
+                    elementsToCheck = children;
+                }
+
+                results["svg"] = results["svg"] || { count: 0, };
+                results["svg"].count++;
+
+                if (elementHasTranform)
+                {
+                    results["svg"]["transform"] = results["svg"]["transform"] || { count: 0, };
+                    results["svg"]["transform"].count++;
+                }
+
+                if (elementHas3DStyle)
+                {
+                    results["svg"]["transform-style_preserve-3d"] = results["svg"]["transform-style_preserve-3d"] || { count: 0, };
+                    results["svg"]["transform-style_preserve-3d"].count++;
+                }
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/cssUsage.src.js
+++ b/cssUsage.src.js
@@ -1650,6 +1650,75 @@ void function() {
 }();
 
 /* 
+    RECIPE: svg_css-transform_preserve-3d
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of svg elements on page along with how many contain the transform CSS property and the transform-style CSS property with value preserve-3d in their namespace.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function svg_css_transform_preserve_3d(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "svg")
+            {
+                var elementsToCheck = [element];
+                var elementHasTranform = false;
+                var elementHas3DStyle = false;
+
+                while (elementsToCheck.length > 0 && (!elementHas3DStyle || !elementHasTranform))
+                {
+                    var children = [];
+
+                    for (var i = 0; i < elementsToCheck.length; ++i)
+                    {
+                        var e = elementsToCheck[i];
+
+                        // If no CSS on element, then don't do what is inside if statement, otherwise it will hit error.
+                        if (e.CSSUsage)
+                        {
+                            if (e.CSSUsage["transform"]) {
+                                elementHasTranform = true;
+                            }
+
+                            // We have to check for the transform-style property first before checking its values, otherwise it will hit error.
+                            var transformStyle = e.CSSUsage["transform-style"];
+                            if (transformStyle)
+                            {
+                                if (transformStyle.valuesArray.includes("preserve-3d")) {
+                                    elementHas3DStyle = true;
+                                }
+                            }
+                        }
+
+                        // Need to convert children HTML collection to array to combine with other children found.
+                        children = children.concat(Array.from(e.children));
+                    }
+                    elementsToCheck = children;
+                }
+
+                results["svg"] = results["svg"] || { count: 0, };
+                results["svg"].count++;
+
+                if (elementHasTranform)
+                {
+                    results["svg"]["transform"] = results["svg"]["transform"] || { count: 0, };
+                    results["svg"]["transform"].count++;
+                }
+
+                if (elementHas3DStyle)
+                {
+                    results["svg"]["transform-style_preserve-3d"] = results["svg"]["transform-style_preserve-3d"] || { count: 0, };
+                    results["svg"]["transform-style_preserve-3d"].count++;
+                }
+            }
+
+            return results;
+        });
+}();
+
+/* 
     RECIPE: z-index on static flex items
     -------------------------------------------------------------
     Author: Francois Remy

--- a/src/recipes/svg_css-transform_preserve-3d.js
+++ b/src/recipes/svg_css-transform_preserve-3d.js
@@ -1,0 +1,68 @@
+/* 
+    RECIPE: svg_css-transform_preserve-3d
+    -------------------------------------------------------------
+    Author: joevery
+    Description: Get count of svg elements on page along with how many contain the transform CSS property and the transform-style CSS property with value preserve-3d in their namespace.
+*/
+void function() {
+    window.CSSUsage.StyleWalker.recipesToRun.push(
+        function svg_css_transform_preserve_3d(element, results) 
+        {
+            var nodeName = element.nodeName;
+
+            if (nodeName == "svg")
+            {
+                var elementsToCheck = [element];
+                var elementHasTranform = false;
+                var elementHas3DStyle = false;
+
+                while (elementsToCheck.length > 0 && (!elementHas3DStyle || !elementHasTranform))
+                {
+                    var children = [];
+
+                    for (var i = 0; i < elementsToCheck.length; ++i)
+                    {
+                        var e = elementsToCheck[i];
+
+                        // If no CSS on element, then don't do what is inside if statement, otherwise it will hit error.
+                        if (e.CSSUsage)
+                        {
+                            if (e.CSSUsage["transform"]) {
+                                elementHasTranform = true;
+                            }
+
+                            // We have to check for the transform-style property first before checking its values, otherwise it will hit error.
+                            var transformStyle = e.CSSUsage["transform-style"];
+                            if (transformStyle)
+                            {
+                                if (transformStyle.valuesArray.includes("preserve-3d")) {
+                                    elementHas3DStyle = true;
+                                }
+                            }
+                        }
+
+                        // Need to convert children HTML collection to array to combine with other children found.
+                        children = children.concat(Array.from(e.children));
+                    }
+                    elementsToCheck = children;
+                }
+
+                results["svg"] = results["svg"] || { count: 0, };
+                results["svg"].count++;
+
+                if (elementHasTranform)
+                {
+                    results["svg"]["transform"] = results["svg"]["transform"] || { count: 0, };
+                    results["svg"]["transform"].count++;
+                }
+
+                if (elementHas3DStyle)
+                {
+                    results["svg"]["transform-style_preserve-3d"] = results["svg"]["transform-style_preserve-3d"] || { count: 0, };
+                    results["svg"]["transform-style_preserve-3d"].count++;
+                }
+            }
+
+            return results;
+        });
+}();

--- a/tests/recipes/svg_css-transform_preserve-3d.html
+++ b/tests/recipes/svg_css-transform_preserve-3d.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>SVG CSS transform and preserve-3d test</title>
+    <style>
+        text {
+            width: 70%;
+            margin: 0 auto;
+            display: block;
+            transform: perspective(300px) rotateX(30deg);
+            transform-style: preserve-3d;
+        }
+    </style>
+    <script src="../../Recipe.min.js"></script>
+</head>
+<body>
+    <svg viewBox="0 0 100 100">
+        <g>
+            <circle cx="20" cy="20" r="20"/>
+            <text x="0" y="20">YAY!!!!!!!!!!!</text>
+        </g>
+    </svg>
+</body>
+</html>


### PR DESCRIPTION
I have created a Crawler recipe to count the number of svg elements on each page and then also indicate how many of these have the transform CSS property applied and the transform-style CSS property applied with value "preserve-3d".

**I ran this recipe against a small list of URLs and it seemed to work okay.**